### PR TITLE
Fix accept-eula.sh permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY accept-eula.sh ${PETA_RUN_FILE} /
 
 # run the install
 RUN chmod a+x /${PETA_RUN_FILE} && \
+  chmod a+rx /accept-eula.sh && \
   mkdir -p /opt/Xilinx && \
   chmod 777 /tmp /opt/Xilinx && \
   cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN adduser --disabled-password --gecos '' vivado && \
 COPY accept-eula.sh ${PETA_RUN_FILE} /
 
 # run the install
-RUN chmod a+x /${PETA_RUN_FILE} && \
+RUN chmod a+rx /${PETA_RUN_FILE} && \
   chmod a+rx /accept-eula.sh && \
   mkdir -p /opt/Xilinx && \
   chmod 777 /tmp /opt/Xilinx && \


### PR DESCRIPTION
The vivado user does not have read access to accept-eula.sh. Fixes "couldn't read file "/accept-eula.sh": permission denied".